### PR TITLE
Adjust/remove obsolete links

### DIFF
--- a/content/resources.html
+++ b/content/resources.html
@@ -18,9 +18,7 @@
     Starting point with a long list of references and tools.</li>
   <li><a class="extern" href="http://www.bullseye.com/coverage.html">Steve Cornett: "Code Coverage Analysis"</a> -
     A comprehensive description of different coverage measures.</li>
-  <li><a class="extern" href="http://homepage.mac.com/hey.you/lessons.html">Tony Obermeit: "Code Coverage Lessons"</a> -
-    Read why Tony recommends 100% code coverage for your test suites.</li>
-  <li><a class="extern" href="http://www-128.ibm.com/developerworks/java/library/j-cq01316/">Andrew Glover: "Don't be fooled by the coverage report"</a> -
+  <li><a class="extern" href="http://www.ibm.com/developerworks/java/library/j-cq01316/">Andrew Glover: "Don't be fooled by the coverage report"</a> -
     This article shows some risks when misusing coverage reports in projects.</li>
 </ul>
 
@@ -55,11 +53,11 @@
 <h2>Articles About EclEmma</h2>
 
 <ul>
-  <li>Tests f&uuml;r die Tests by Marc R. Hoffmann, <a class="extern" href="http://it-republik.de/jaxenter/eclipse-magazin-ausgaben/Android-000442.html">Eclipse Magazin Vol. 3.2011</a>, 2011/03/25 [de]</li>
-  <li>EclEmma by Richard Attermeyer, <a class="extern" href="http://it-republik.de/jaxenter/eclipse-magazin-ausgaben/Plug-in-Parade-000340.html">Eclipse Magazin Vol. 2.2010</a>, 2010/01/27 [de]</li>
+  <li>Tests f&uuml;r die Tests by Marc R. Hoffmann, Eclipse Magazin Vol. 3.2011, 2011/03/25 [de]</li>
+  <li>EclEmma by Richard Attermeyer, Eclipse Magazin Vol. 2.2010, 2010/01/27 [de]</li>
   <li><a class="extern" href="http://agile.csc.ncsu.edu/SEMaterials/tutorials/eclemma/">Test Coverage with EclEmma</a> by Laurie Williams, Ben Smith and Sarah Heckman, <a class="extern" href="http://www.ncsu.edu/">North Carolina State University</a>, 2009/03/30</li>
-  <li>Testabdeckung mit Open-Source-Tools by Tim Wellhausen, <a class="extern" href="http://www.sigs-datacom.de/sd/publications/js/2008/06/index.htm">JavaSpektrum</a>, 2008/06/01 [de]</li>
-  <li>EclEmma by Benjamin Muskalla, <a class="extern" href="http://it-republik.de/jaxenter/eclipse-magazin-ausgaben/Wizards-und-Dialoge-mit-Eclipse-RCP-000082.html">Eclipse Magazin Vol. 11</a>, 2007/06/05 [de]</li>
+  <li>Testabdeckung mit Open-Source-Tools by Tim Wellhausen, JavaSpektrum, 2008/06/01 [de]</li>
+  <li>EclEmma by Benjamin Muskalla, Eclipse Magazin Vol. 11, 2007/06/05 [de]</li>
   <li><a class="extern" href="http://www.ibm.com/developerworks/cn/java/j-lo-eclemma/index.html">Coverage Test Made Easy with EclEmma</a> by Dr. James Gan, 2007/05/17 [zh]</li>
 </ul>
 
@@ -72,21 +70,16 @@
   <li><a class="extern" href="http://blog.eisele.net/2011/04/test-coverage-for-your-enterprise-beans.html">Test Coverage for your Enterprise Beans. Running Eclemma with GlassFish 3.1</a> by Markus Eisele, 2011/04/05</li>
   <li><a class="extern" href="http://blog.fabianpiau.com/en/2009/11/11/do-you-need-a-good-cover-for-this-winter-eclemma/">Do you need a good cover for this winter?</a> by Fabian Piau, 2009/11/08</li>
   <li><a class="extern" href="http://tratandodeentenderlo.blogspot.com/2009/11/visualizar-la-cobertura-de-los-tests.html">EclEmma: Visualizar la cobertura de los tests unitarios en Eclipse</a> by tratandodeentenderlo, 2009/11/06 [es]</li>
-  <li><a class="extern" href="http://margelatu.org/2009/06/25/java-code-coverage-reports-in-eclipse/">Java code coverage reports in Eclipse</a> by Margelatu, 2009/06/25</li>
   <li><a class="extern" href="http://geek.starbean.net/?p=237">EclEmma</a> by Geek, 2009/04/19</li>
   <li><a class="extern" href="http://bartling.blogspot.com/2008/12/eclemma-code-coverage-plugin-for.html">EclEmma, a code coverage plugin for Eclipse</a> by Chris Bartling, 2008/12/05</li>
   <li><a class="extern" href="http://codesmell.wordpress.com/2008/10/22/keep-cover/">Keep Cover!</a> by Uwe Schaefer, 2008/10/22</li>
-  <li><a class="extern" href="http://jmbeas.blogspot.com/2008/08/code-coverage-en-eclipse.html">Code Coverage en Eclipse</a> by Jos&eacute; Manuel Beas, 2008/08/08 [es]</li>
   <li><a class="extern" href="http://shyamseshadri.blogspot.com/2008/07/of-emmas-and-eclipses.html">Of EMMA's and Eclipse's</a> by Shyam Seshadri, 2008/07/20</li>
-  <li><a class="extern" href="http://ericanderson.us/2008/05/08/using-eclemma-to-write-better-unit-tests/">Using EclEmma to Write Better Unit Tests</a> by Eric Anderson, 2008/05/08</li>
   <li><a class="extern" href="http://zipwow.blogspot.com/2008/01/code-coverage-for-eclipse-redeux.html">Code Coverage for Eclipse redeux: EclEmma</a> by Kevin Klinemeier, 2008/01/08</li>
-  <li><a class="extern" href="http://curious-attempt-bunny.blogspot.com/2007/11/great-code-coverage-plugin-for-eclipse.html">Great Code Coverage Plugin for Eclipse</a> by Merlyn Albery-Speyer, 2007/11/04</li>
+  <li><a class="extern" href="http://www.curiousattemptbunny.com/2007/11/great-code-coverage-plugin-for-eclipse.html">Great Code Coverage Plugin for Eclipse</a> by Merlyn Albery-Speyer, 2007/11/04</li>
   <li><a class="extern" href="http://dirkmeister.blogspot.com/2007/05/eclipse-emma-plugin-eclemma.html">Eclipse-Emma-Plugin: EclEmma</a> by Dirk Meister, 2007/05/17 [de]</li>
   <li><a class="extern" href="http://tapestryjava.blogspot.com/2007/05/free-and-excellent-code-coverage-for.html">Free and Excellent Code Coverage for Eclipse</a> by Howard Lewis Ship, 2007/05/16</li>
   <li><a class="extern" href="http://brigomp.blogspot.com/2007/02/eclemma-de-lo-mejor-en-cuanto-cobertura.html">EclEmma, de lo mejor en cuanto a cobertura de código</a> by Martin Perez, 2007/02/28 [es]</li>
   <li><a class="extern" href="http://furiouspurpose.blogspot.com/2007/02/eclipse-code-coverage-with-eclemma.html">Eclipse Code Coverage with EclEmma</a> by Geoffrey Wiseman, 2007/02/19</li>
-  <li><a class="extern" href="http://www.i-proving.ca/space/Brett+Dubroy/blog/2006-12-01_2">Eclipse Emma Plug-in</a> by Brett Dubroy, 2006/12/01</li>
-  <li><a class="extern" href="http://jbrugge.com/blog/?p=44">Code Coverage while you work: EclEmma</a> by John Brugge, 2006/11/23</li>
   <li><a class="extern" href="http://bobmccune.com/2006/11/22/eclemma/">EclEmma</a> by Bob McCune, 2006/11/22</li>
   <li><a class="extern" href="http://www.venukb.com/blog/2006/11/22/eclemma-java-code-coverage/">EclEmma - Java Code Coverage</a> by Venukb, 2006/11/22</li>
   <li><a class="extern" href="http://jroller.com/page/aalmiray?entry=code_coverage_on_eclipse_eclemma">Code coverage on Eclipse: EclEmma</a> by Andres Almiray, 2006/11/14</li>


### PR DESCRIPTION
I've got an email :
> Hello Evgeny,
>
> I'm not certain you're the best person to contact, but yours is the first email address I can find, so hopefully you can pass it on as appropriate.
>
> I installed EclEmma recently to do code coverage analysis of our test suite. In the resources section of the EclEmma website, the following at least are dead links:
>
>Tony Obermeit: "Code Coverage Lessons" - Read why Tony recommends 100% code coverage for your test suites.
> Andrew Glover: "Don't be fooled by the coverage report" - This article shows some risks when misusing coverage reports in projects.
>
> Best wishes,
>
> -- 
> Frederic Heath-Renn
> Twickets, Ltd.

Response was - to use mailing list in future for such notifications.
But anyway we should do a check followed by a fix.
