### PR TITLE
Use HTTPS for JaCoCo downloads

### DIFF
--- a/content/jacoco/index.html
+++ b/content/jacoco/index.html
@@ -58,7 +58,7 @@
     <td><b>Checksums</b></td>
   </tr>
   <tr style="background-color:#ccffcc">
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.6/jacoco-0.8.6.zip">jacoco-0.8.6.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.6/jacoco-0.8.6.zip">jacoco-0.8.6.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.6">0.8.6</a></td>
     <td>2020/09/15</td>
     <td>3.8 MB</td>
@@ -66,7 +66,7 @@
         <a href="download/jacoco-0.8.6.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.5/jacoco-0.8.5.zip">jacoco-0.8.5.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.5/jacoco-0.8.5.zip">jacoco-0.8.5.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.5">0.8.5</a></td>
     <td>2019/10/11</td>
     <td>3.8 MB</td>
@@ -74,7 +74,7 @@
         <a href="download/jacoco-0.8.5.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.4/jacoco-0.8.4.zip">jacoco-0.8.4.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.4/jacoco-0.8.4.zip">jacoco-0.8.4.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.4">0.8.4</a></td>
     <td>2019/05/08</td>
     <td>3.7 MB</td>
@@ -82,7 +82,7 @@
         <a href="download/jacoco-0.8.4.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.3/jacoco-0.8.3.zip">jacoco-0.8.3.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.3/jacoco-0.8.3.zip">jacoco-0.8.3.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.3">0.8.3</a></td>
     <td>2019/01/23</td>
     <td>3.7 MB</td>
@@ -90,7 +90,7 @@
         <a href="download/jacoco-0.8.3.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.2/jacoco-0.8.2.zip">jacoco-0.8.2.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.2/jacoco-0.8.2.zip">jacoco-0.8.2.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.2">0.8.2</a></td>
     <td>2018/08/21</td>
     <td>3.6 MB</td>
@@ -98,7 +98,7 @@
         <a href="download/jacoco-0.8.2.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.1/jacoco-0.8.1.zip">jacoco-0.8.1.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.1/jacoco-0.8.1.zip">jacoco-0.8.1.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.1">0.8.1</a></td>
     <td>2018/03/21</td>
     <td>3.4 MB</td>
@@ -106,7 +106,7 @@
         <a href="download/jacoco-0.8.1.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.0/jacoco-0.8.0.zip">jacoco-0.8.0.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.0/jacoco-0.8.0.zip">jacoco-0.8.0.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.8.0">0.8.0</a></td>
     <td>2018/01/02</td>
     <td>3.4 MB</td>
@@ -114,7 +114,7 @@
         <a href="download/jacoco-0.8.0.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.9/jacoco-0.7.9.zip">jacoco-0.7.9.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.9/jacoco-0.7.9.zip">jacoco-0.7.9.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.9">0.7.9</a></td>
     <td>2017/02/05</td>
     <td>2.9 MB</td>
@@ -122,7 +122,7 @@
         <a href="download/jacoco-0.7.9.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.8/jacoco-0.7.8.zip">jacoco-0.7.8.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.8/jacoco-0.7.8.zip">jacoco-0.7.8.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.8">0.7.8</a></td>
     <td>2016/12/10</td>
     <td>2.9 MB</td>
@@ -130,7 +130,7 @@
         <a href="download/jacoco-0.7.8.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.7.201606060606/jacoco-0.7.7.201606060606.zip">jacoco-0.7.7.201606060606.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.7.201606060606/jacoco-0.7.7.201606060606.zip">jacoco-0.7.7.201606060606.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.7">0.7.7</a></td>
     <td>2016/06/06</td>
     <td>2.9 MB</td>
@@ -138,7 +138,7 @@
         <a href="download/jacoco-0.7.7.201606060606.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.6.201602180812/jacoco-0.7.6.201602180812.zip">jacoco-0.7.6.201602180812.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.6.201602180812/jacoco-0.7.6.201602180812.zip">jacoco-0.7.6.201602180812.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.6">0.7.6</a></td>
     <td>2016/02/18</td>
     <td>2.9 MB</td>
@@ -146,7 +146,7 @@
         <a href="download/jacoco-0.7.6.201602180812.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.5.201505241946/jacoco-0.7.5.201505241946.zip">jacoco-0.7.5.201505241946.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.5.201505241946/jacoco-0.7.5.201505241946.zip">jacoco-0.7.5.201505241946.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.5">0.7.5</a></td>
     <td>2015/05/24</td>
     <td>2.9 MB</td>
@@ -154,7 +154,7 @@
         <a href="download/jacoco-0.7.5.201505241946.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.4.201502262128/jacoco-0.7.4.201502262128.zip">jacoco-0.7.4.201502262128.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.4.201502262128/jacoco-0.7.4.201502262128.zip">jacoco-0.7.4.201502262128.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.4">0.7.4</a></td>
     <td>2015/02/26</td>
     <td>2.9 MB</td>
@@ -162,7 +162,7 @@
         <a href="download/jacoco-0.7.4.201502262128.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.3.201502191951/jacoco-0.7.3.201502191951.zip">jacoco-0.7.3.201502191951.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.3.201502191951/jacoco-0.7.3.201502191951.zip">jacoco-0.7.3.201502191951.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.3">0.7.3</a></td>
     <td>2015/02/19</td>
     <td>2.9 MB</td>
@@ -170,7 +170,7 @@
         <a href="download/jacoco-0.7.3.201502191951.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.2.201409121644/jacoco-0.7.2.201409121644.zip">jacoco-0.7.2.201409121644.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.2.201409121644/jacoco-0.7.2.201409121644.zip">jacoco-0.7.2.201409121644.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.2">0.7.2</a></td>
     <td>2014/09/12</td>
     <td>2.9 MB</td>
@@ -178,7 +178,7 @@
         <a href="download/jacoco-0.7.2.201409121644.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.1.201405082137/jacoco-0.7.1.201405082137.zip">jacoco-0.7.1.201405082137.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.1.201405082137/jacoco-0.7.1.201405082137.zip">jacoco-0.7.1.201405082137.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.1">0.7.1</a></td>
     <td>2014/05/08</td>
     <td>2.9 MB</td>
@@ -186,7 +186,7 @@
         <a href="download/jacoco-0.7.1.201405082137.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.0.201403182114/jacoco-0.7.0.201403182114.zip">jacoco-0.7.0.201403182114.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.7.0.201403182114/jacoco-0.7.0.201403182114.zip">jacoco-0.7.0.201403182114.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.7.0">0.7.0</a></td>
     <td>2014/03/18</td>
     <td>2.9 MB</td>
@@ -194,7 +194,7 @@
         <a href="download/jacoco-0.7.0.201403182114.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.5.201403032054/jacoco-0.6.5.201403032054.zip">jacoco-0.6.5.201403032054.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.5.201403032054/jacoco-0.6.5.201403032054.zip">jacoco-0.6.5.201403032054.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.6.5">0.6.5</a></td>
     <td>2014/03/03</td>
     <td>2.6 MB</td>
@@ -202,7 +202,7 @@
         <a href="download/jacoco-0.6.5.201403032054.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.4.201312101107/jacoco-0.6.4.201312101107.zip">jacoco-0.6.4.201312101107.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.4.201312101107/jacoco-0.6.4.201312101107.zip">jacoco-0.6.4.201312101107.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.6.4">0.6.4</a></td>
     <td>2013/12/10</td>
     <td>2.5 MB</td>
@@ -210,7 +210,7 @@
         <a href="download/jacoco-0.6.4.201312101107.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.3.201306030806/jacoco-0.6.3.201306030806.zip">jacoco-0.6.3.201306030806.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.3.201306030806/jacoco-0.6.3.201306030806.zip">jacoco-0.6.3.201306030806.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.6.3">0.6.3</a></td>
     <td>2013/06/03</td>
     <td>2.4 MB</td>
@@ -218,7 +218,7 @@
         <a href="download/jacoco-0.6.3.201306030806.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.2.201302030002/jacoco-0.6.2.201302030002.zip">jacoco-0.6.2.201302030002.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.2.201302030002/jacoco-0.6.2.201302030002.zip">jacoco-0.6.2.201302030002.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.6.2">0.6.2</a></td>
     <td>2013/02/03</td>
     <td>2.3 MB</td>
@@ -226,7 +226,7 @@
         <a href="download/jacoco-0.6.2.201302030002.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.1.201212231917/jacoco-0.6.1.201212231917.zip">jacoco-0.6.1.201212231917.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.1.201212231917/jacoco-0.6.1.201212231917.zip">jacoco-0.6.1.201212231917.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.6.1">0.6.1</a></td>
     <td>2012/12/23</td>
     <td>2.2 MB</td>
@@ -234,7 +234,7 @@
         <a href="download/jacoco-0.6.1.201212231917.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.0.201210061924/jacoco-0.6.0.201210061924.zip">jacoco-0.6.0.201210061924.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.6.0.201210061924/jacoco-0.6.0.201210061924.zip">jacoco-0.6.0.201210061924.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.6.0">0.6.0</a></td>
     <td>2012/10/06</td>
     <td>3.2 MB</td>
@@ -242,7 +242,7 @@
         <a href="download/jacoco-0.6.0.201210061924.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.10.201208310627/jacoco-0.5.10.201208310627.zip">jacoco-0.5.10.201208310627.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.10.201208310627/jacoco-0.5.10.201208310627.zip">jacoco-0.5.10.201208310627.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.10">0.5.10</a></td>
     <td>2012/08/31</td>
     <td>2.2 MB</td>
@@ -250,7 +250,7 @@
         <a href="download/jacoco-0.5.10.201208310627.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.9.201207300726/jacoco-0.5.9.201207300726.zip">jacoco-0.5.9.201207300726.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.9.201207300726/jacoco-0.5.9.201207300726.zip">jacoco-0.5.9.201207300726.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.9">0.5.9</a></td>
     <td>2012/07/30</td>
     <td>2.2 MB</td>
@@ -258,7 +258,7 @@
         <a href="download/jacoco-0.5.9.201207300726.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.8.201207111220/jacoco-0.5.8.201207111220.zip">jacoco-0.5.8.201207111220.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.8.201207111220/jacoco-0.5.8.201207111220.zip">jacoco-0.5.8.201207111220.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.8">0.5.8</a></td>
     <td>2012/07/11</td>
     <td>2.2 MB</td>
@@ -266,7 +266,7 @@
         <a href="download/jacoco-0.5.8.201207111220.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.7.201204190339/jacoco-0.5.7.201204190339.zip">jacoco-0.5.7.201204190339.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.7.201204190339/jacoco-0.5.7.201204190339.zip">jacoco-0.5.7.201204190339.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.7">0.5.7</a></td>
     <td>2012/04/19</td>
     <td>2.1 MB</td>
@@ -274,7 +274,7 @@
         <a href="download/jacoco-0.5.7.201204190339.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.6.201201232323/jacoco-0.5.6.201201232323.zip">jacoco-0.5.6.201201232323.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.6.201201232323/jacoco-0.5.6.201201232323.zip">jacoco-0.5.6.201201232323.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.6">0.5.6</a></td>
     <td>2012/01/23</td>
     <td>2.1 MB</td>
@@ -282,7 +282,7 @@
         <a href="download/jacoco-0.5.6.201201232323.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.5.201112152213/jacoco-0.5.5.201112152213.zip">jacoco-0.5.5.201112152213.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.5.201112152213/jacoco-0.5.5.201112152213.zip">jacoco-0.5.5.201112152213.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.5">0.5.5</a></td>
     <td>2011/12/15</td>
     <td>2.1 MB</td>
@@ -290,7 +290,7 @@
         <a href="download/jacoco-0.5.5.201112152213.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.4.201111111111/jacoco-0.5.4.201111111111.zip">jacoco-0.5.4.201111111111.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.4.201111111111/jacoco-0.5.4.201111111111.zip">jacoco-0.5.4.201111111111.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.4">0.5.4</a></td>
     <td>2011/11/11</td>
     <td>2.1 MB</td>
@@ -298,7 +298,7 @@
         <a href="download/jacoco-0.5.4.201111111111.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.3.201107060350/jacoco-0.5.3.201107060350.zip">jacoco-0.5.3.201107060350.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.3.201107060350/jacoco-0.5.3.201107060350.zip">jacoco-0.5.3.201107060350.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.3">0.5.3</a></td>
     <td>2011/07/06</td>
     <td>2.0 MB</td>
@@ -306,7 +306,7 @@
         <a href="download/jacoco-0.5.3.201107060350.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.2.20110519202509/jacoco-0.5.2.20110519202509.zip">jacoco-0.5.2.20110519202509.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.2.20110519202509/jacoco-0.5.2.20110519202509.zip">jacoco-0.5.2.20110519202509.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.2">0.5.2</a></td>
     <td>2011/05/19</td>
     <td>1.8 MB</td>
@@ -314,7 +314,7 @@
         <a href="download/jacoco-0.5.2.20110519202509.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.1.20110321224001/jacoco-0.5.1.20110321224001.zip">jacoco-0.5.1.20110321224001.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.1.20110321224001/jacoco-0.5.1.20110321224001.zip">jacoco-0.5.1.20110321224001.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.1">0.5.1</a></td>
     <td>2011/03/21</td>
     <td>1.8 MB</td>
@@ -322,7 +322,7 @@
         <a href="download/jacoco-0.5.1.20110321224001.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.0.20110119215959/jacoco-0.5.0.20110119215959.zip">jacoco-0.5.0.20110119215959.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.5.0.20110119215959/jacoco-0.5.0.20110119215959.zip">jacoco-0.5.0.20110119215959.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.5.0">0.5.0</a></td>
     <td>2011/01/19</td>
     <td>1.9 MB</td>
@@ -330,7 +330,7 @@
         <a href="download/jacoco-0.5.0.20110119215959.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.4.1.20101007204400/jacoco-0.4.1.20101007204400.zip">jacoco-0.4.1.20101007204400.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.4.1.20101007204400/jacoco-0.4.1.20101007204400.zip">jacoco-0.4.1.20101007204400.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.4.1">0.4.1</a></td>
     <td>2010/10/07</td>
     <td>1.9 MB</td>
@@ -338,7 +338,7 @@
         <a href="download/jacoco-0.4.1.20101007204400.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.4.0.20100604151516/jacoco-0.4.0.20100604151516.zip">jacoco-0.4.0.20100604151516.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.4.0.20100604151516/jacoco-0.4.0.20100604151516.zip">jacoco-0.4.0.20100604151516.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.4.0">0.4.0</a></td>
     <td>2010/06/04</td>
     <td>1.7 MB</td>
@@ -346,7 +346,7 @@
         <a href="download/jacoco-0.4.0.20100604151516.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.3.20100419191644/jacoco-0.3.3.20100419191644.zip">jacoco-0.3.3.20100419191644.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.3.20100419191644/jacoco-0.3.3.20100419191644.zip">jacoco-0.3.3.20100419191644.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.3.3">0.3.3</a></td>
     <td>2010/04/19</td>
     <td>1.5 MB</td>
@@ -354,7 +354,7 @@
         <a href="download/jacoco-0.3.3.20100419191644.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.2.20100401180959/jacoco-0.3.2.20100401180959.zip">jacoco-0.3.2.20100401180959.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.2.20100401180959/jacoco-0.3.2.20100401180959.zip">jacoco-0.3.2.20100401180959.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.3.2">0.3.2</a></td>
     <td>2010/04/01</td>
     <td>1.5 MB</td>
@@ -362,7 +362,7 @@
         <a href="download/jacoco-0.3.2.20100401180959.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.1.20100209212101/jacoco-0.3.1.20100209212101.zip">jacoco-0.3.1.20100209212101.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.1.20100209212101/jacoco-0.3.1.20100209212101.zip">jacoco-0.3.1.20100209212101.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.3.1">0.3.1</a></td>
     <td>2010/02/09</td>
     <td>1.5 MB</td>
@@ -370,7 +370,7 @@
         <a href="download/jacoco-0.3.1.20100209212101.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.0.20100202223831/jacoco-0.3.0.20100202223831.zip">jacoco-0.3.0.20100202223831.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.3.0.20100202223831/jacoco-0.3.0.20100202223831.zip">jacoco-0.3.0.20100202223831.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.3.0">0.3.0</a></td>
     <td>2010/02/02</td>
     <td>1.5 MB</td>
@@ -378,7 +378,7 @@
         <a href="download/jacoco-0.3.0.20100202223831.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.2.0.20100108061321/jacoco-0.2.0.20100108061321.zip">jacoco-0.2.0.20100108061321.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.2.0.20100108061321/jacoco-0.2.0.20100108061321.zip">jacoco-0.2.0.20100108061321.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.2.0">0.2.0</a></td>
     <td>2010/01/08</td>
     <td>1.4 MB</td>
@@ -386,7 +386,7 @@
         <a href="download/jacoco-0.2.0.20100108061321.zip.sha256.txt">sha256</a></td>
   </tr>
   <tr>
-    <td><a href="http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.1.0.20091028042923/jacoco-0.1.0.20091028042923.zip">jacoco-0.1.0.20091028042923.zip</a></td>
+    <td><a href="https://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.1.0.20091028042923/jacoco-0.1.0.20091028042923.zip">jacoco-0.1.0.20091028042923.zip</a></td>
     <td><a href="https://github.com/jacoco/jacoco/tree/v0.1.0">0.1.0</a></td>
     <td>2009/10/28</td>
     <td>1.3 MB</td>


### PR DESCRIPTION
Using
Google Chrome Version 85.0.4183.121 (Official Build)
while trying to download any released JaCoCo version from page
https://www.jacoco.org/jacoco/index.html

I'm getting

<img width="422" alt="jacoco-downloading" src="https://user-images.githubusercontent.com/138671/94670919-75c46800-0313-11eb-8834-840cf046ce48.png">

"Keep" allows to download file,
"Learn more" points to https://support.google.com/chrome/answer/6261569
that states

> Chrome may also block insecure downloads from secure sites.

i.e. non-HTTPS downloads started on HTTPS pages.

And according to https://blog.chromium.org/2020/02/protecting-users-from-insecure.html next Chrome Version 86 will entirely block such downloads.